### PR TITLE
Merge upstream changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: Spark Framework CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ '1.8', '1.9', '1.10', '1.11' ]
+    name: Java Version ${{ matrix.java }}
+    steps:
+      - uses: actions/checkout@master
+      - name: Setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+          architecture: x64
+      - run: ./mvnw test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: java
 dist: trusty
 jdk:
   - oraclejdk8
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 Spark - a tiny web framework for Java 8
 ==============================================
 
-**Spark 2.9.3 is out!!**  <a href="https://github.com/perwendel/spark/blob/master/changeset/2.9.3-changeset.md">Changeset</a> 
+**Spark 2.9.4 is out!!**
 ```xml
 <dependency>
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-core</artifactId>
-    <version>2.9.3</version>
+    <version>2.9.4</version>
 </dependency>
 ```
 
@@ -31,7 +31,7 @@ Getting started
 <dependency>
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-core</artifactId>
-    <version>2.9.2</version>
+    <version>2.9.4</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <jetty.version>9.4.39.v20210325</jetty.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <powermock.version>1.7.4</powermock.version>
         <mockito.version>1.10.19</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <jetty.version>9.4.33.v20201020</jetty.version>
+        <jetty.version>9.4.39.v20210325</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <powermock.version>1.7.4</powermock.version>
         <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
Merge upstream changes, which will bump Jetty 9 to the latest version, fixing CVE issues.
And also disables server version response header, to make us compliant with https://owasp.org/www-project-top-ten/